### PR TITLE
Update backend README build instructions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -11,4 +11,13 @@ npm start      # start server
 
 ## Deployment on Railway
 
-Set root directory to `/backend` and start command `npm start`. Use `.env` based on `.env.example`.
+Set the root directory to `/backend`.
+
+### Build command
+
+Railway and Render automatically run `npm install` if no build command is provided.
+For reproducible installs, you can set the build step to `npm ci`.
+
+### Start command
+
+Use `npm start`. Configure environment variables based on `.env.example`.


### PR DESCRIPTION
## Summary
- document default build step on hosting providers
- clarify build and start command sections

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fb11587e883299f6e5222428b05e6