### PR TITLE
Implement centralized error middleware

### DIFF
--- a/backend/src/controllers/transcripts.js
+++ b/backend/src/controllers/transcripts.js
@@ -11,9 +11,13 @@ exports.uploadAudio = async (req, res, next) => {
 
 exports.getTranscript = async (req, res, next) => {
   try {
-    const transcript = await services.findTranscript(req.params.id);
-    if (!transcript) return res.status(404).json({ error: 'Not found' });
-    res.json(transcript);
+  const transcript = await services.findTranscript(req.params.id);
+  if (!transcript) {
+    const error = new Error('Not found');
+    error.status = 404;
+    return next(error);
+  }
+  res.json(transcript);
   } catch (err) {
     next(err);
   }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,6 +2,9 @@ const express = require('express');
 const cors = require('cors');
 const morgan = require('morgan');
 const routes = require('./routes');
+const notFound = require('./middleware/notFound');
+const errorHandler = require('./middleware/errorHandler');
+const logger = require('./utils/logger');
 require('dotenv').config();
 
 const app = express();
@@ -11,12 +14,10 @@ app.use(morgan('dev'));
 
 app.use('/api', routes);
 
-app.use((err, req, res, next) => {
-  console.error(err); // TODO: replace with logger
-  res.status(500).json({ error: 'Internal Server Error' });
-});
+app.use(notFound);
+app.use(errorHandler);
 
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
+  logger.info(`Server running on port ${PORT}`); // integrate logger here
 });

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,0 +1,15 @@
+const logger = require('../utils/logger');
+
+module.exports = (err, req, res, next) => {
+  const status = err.status || 500;
+
+  if (status >= 500) {
+    // Integrate server-side logging here
+    logger.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  } else {
+    // Integrate client error logging here
+    logger.info(err.message);
+    res.status(status).json({ error: err.message });
+  }
+};

--- a/backend/src/middleware/notFound.js
+++ b/backend/src/middleware/notFound.js
@@ -1,0 +1,5 @@
+module.exports = (req, res, next) => {
+  const error = new Error('Not Found');
+  error.status = 404;
+  next(error);
+};

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -1,0 +1,7 @@
+/**
+ * Placeholder logger. Replace with your preferred logging library (e.g., Winston or Pino).
+ */
+module.exports = {
+  info: (...args) => console.log(...args),
+  error: (...args) => console.error(...args),
+};


### PR DESCRIPTION
## Summary
- add placeholder logger utility
- create not-found and error-handler middleware
- use middleware in Express app
- update transcripts controller to throw 404 using middleware

## Testing
- `npm run build` in frontend
- `npm test` *(fails: Missing script)*
- `PORT=3005 node backend/src/index.js & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_683fb116af9083299d726a39d89d0fd2